### PR TITLE
FIX: Update url praser for GitLab

### DIFF
--- a/utils/uiParser.js
+++ b/utils/uiParser.js
@@ -22,23 +22,34 @@ var getUiInfo = async function({
 // Parse url to get the commit info
 function parseURL(url) {
 
-    /** URL pattern in GitHub:GitLab
+    /** URL pattern in GitHub
      * new:	<SERVER>/<user>/<repo>/new/<branch>/<fpath>
      * edit:	<SERVER>/<user>/<repo>/edit/<branch>/<fpath>
-     * delete:	<SERVER>/<user>/<repo>/delete:blob/<branch>/<fpath>
-     * upload:	<SERVER>/<user>/<repo>/upload:tree/<branch>/<fpath> 
-     * merge:	<SERVER>/<user>/<repo>/pull:merge_requests/<pr#>
+     * delete:	<SERVER>/<user>/<repo>/delete/<branch>/<fpath>
+     * upload:	<SERVER>/<user>/<repo>/upload/<branch>/<fpath>
+     * merge:	<SERVER>/<user>/<repo>/pull/<pr#>
+     **/
+
+    /** URL pattern in GitLab
+     * new:	<SERVER>/<user>/<repo>/-/new/<branch>/<fpath>
+     * edit:	<SERVER>/<user>/<repo>/-/edit/<branch>/<fpath>
+     * delete:	<SERVER>/<user>/<repo>/-/blob/<branch>/<fpath>
+     * upload:	<SERVER>/<user>/<repo>/-/tree/<branch>/<fpath>
+     * merge:	<SERVER>/<user>/<repo>/-/merge_requests/<pr#>
      **/
 
     let info = url.replace(`${SERVER}`, "").split("/");
 
-    // RULE: requests on the main page are ignored
+    // The extension does not work on the main page of repo
     if (info.length < 4) {
         deactivate({
             rule: UNKNOWN_REQUEST
         });
         return UNKNOWN_REQUEST;
     }
+
+    // Remove an extra element (i.e. "-") from the GitLab url
+    if (SERVER = SERVER_GL) info.splice(3,1);
 
     let commitType = info[3];
     let baseBranch = null;


### PR DESCRIPTION
**This PR introduces**

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Code style update
- [ ] Other, please describe:

**Description of the PR**

Previously, a URL associated with commits on the GitLab server could be described as follows:
```
  regular commit: gitlab.com/<user>/<repo>/<TYPE>/<branch>/<filepath>
  merge commit: gitlab.com/<user>/<repo>/merge_requests/<PR#>
```

Now, GitLab has made minor changes to the URL by inserting a dash (-) right after the repo name.

```
  regular commit: gitlab.com/<user>/<repo>/-/<TYPE>/<branch>/<filepath>
  merge commit: gitlab.com/<user>/<repo>/-/merge_requests/<PR#>
```

To comply with this change on the GitLab server, we need to update the extension's url parser.